### PR TITLE
fix(ios): run endSigningSession DSMManager calls on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixes
 
+- **iOS**: `endSigningSession` no longer calls `DSMManager` off the main thread. Expo dispatches a synchronous `AsyncFunction` body on a serial background queue, so `clearAllWebCookies()` and `logout()` were reached off-main on every call, including the one `useDocuSignSigning`'s `reset()` makes between flows. The guard now lives in `clearWebCookiesAsync`, the only method touching `DSMManager` and `WKWebsiteDataStore` directly, so it covers every caller. Thanks to @virajpsimformsolutions for finding and fixing this.
+- **iOS**: `reset()` no longer re-enters itself to reach the main thread. The hop sat below the block that cancels an in-flight signing promise, so the re-entrant pass ran that block twice and could cancel a session that claimed the slot in between.
 - **iOS**: reject a blank or non-`https` `signingUrl` before presenting. `DSMEnvelopesManager.presentCaptiveSigning` validates nothing and presents unconditionally, so a malformed URL rendered an empty signing controller whose completion never fired and left the promise unsettled. `signingUrl` defaults to `""` when JS omits it, so this was reachable without a malformed URL at all. Brings iOS to parity with the Android guard below.
 - **Android**: reject a blank or non-`https` `signingUrl` before launching. The SDK's URL overload validates nothing and calls `startActivity` unconditionally, so a malformed URL opened an empty signing activity and left the promise unsettled.
 - **Android**: `presentCaptiveSigning` now clears `currentEnvelopeId` when the launch itself throws, matching the URL path.

--- a/ios/DocuSignManager.swift
+++ b/ios/DocuSignManager.swift
@@ -543,6 +543,16 @@ internal final class DocuSignManager: NSObject {
     }
     _ = pendingResolved // silence unused-warning; kept for future telemetry
 
+    // DSMManager APIs (clearAllWebCookies, logout) must run on the main thread.
+    // Expo async functions are dispatched on AsyncFunctionQueue (non-main), so
+    // we must hop to main before touching any DSMManager API.
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async { [weak self] in
+        self?.endSigningSession(completion: completion)
+      }
+      return
+    }
+
     clearWebCookiesAsync { [weak self] in
       guard let self = self else {
         completion()

--- a/ios/DocuSignManager.swift
+++ b/ios/DocuSignManager.swift
@@ -318,7 +318,25 @@ internal final class DocuSignManager: NSObject {
   /// `loginWithAccessToken` runs. If you need to isolate DocuSign's WebKit
   /// state from the rest of your app, use a non-default data store for those
   /// other WebViews.
+  /// Hops to the main thread before touching any DSMManager or WebKit API.
+  ///
+  /// Expo dispatches a synchronous `AsyncFunction` body on a serial background queue, so every
+  /// caller that originates in a JS call arrives here off-main. This is the only method reaching
+  /// `DSMManager.clearAllWebCookies()` and `WKWebsiteDataStore` directly, so one guard here covers
+  /// `performLogin`, `endSigningSession` and `reset` rather than each hopping for itself. The
+  /// completion is dispatched on main below, so callers may touch DSMManager from it.
   private func clearWebCookiesAsync(completion: @escaping () -> Void) {
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async { [weak self] in
+        guard let self = self else {
+          completion()
+          return
+        }
+        self.clearWebCookiesAsync(completion: completion)
+      }
+      return
+    }
+
     DSMManager.clearAllWebCookies()
     let dataStore = WKWebsiteDataStore.default()
     let types = WKWebsiteDataStore.allWebsiteDataTypes()
@@ -526,7 +544,6 @@ internal final class DocuSignManager: NSObject {
   /// free.
   func endSigningSession(completion: @escaping () -> Void) {
     // Resolve any in-flight signing promise so the JS side does not hang.
-    var pendingResolved = false
     stateQueue.sync {
       if let pending = pendingCompletion {
         let outcome = SigningOutcome(
@@ -538,19 +555,7 @@ internal final class DocuSignManager: NSObject {
         pendingCompletion = nil
         currentEnvelopeId = nil
         DispatchQueue.main.async { pending(.success(outcome)) }
-        pendingResolved = true
       }
-    }
-    _ = pendingResolved // silence unused-warning; kept for future telemetry
-
-    // DSMManager APIs (clearAllWebCookies, logout) must run on the main thread.
-    // Expo async functions are dispatched on AsyncFunctionQueue (non-main), so
-    // we must hop to main before touching any DSMManager API.
-    guard Thread.isMainThread else {
-      DispatchQueue.main.async { [weak self] in
-        self?.endSigningSession(completion: completion)
-      }
-      return
     }
 
     clearWebCookiesAsync { [weak self] in
@@ -601,14 +606,9 @@ internal final class DocuSignManager: NSObject {
       return
     }
 
-    if !Thread.isMainThread {
-      DispatchQueue.main.async { [weak self] in
-        guard let self = self else { completion(); return }
-        self.reset(completion: completion)
-      }
-      return
-    }
-
+    // No main-thread hop here. clearWebCookiesAsync guards itself, and re-entering reset() from
+    // main would run the pending-cancellation block above a second time, cancelling any session
+    // that claimed the slot in between.
     clearWebCookiesAsync { [weak self] in
       guard let self = self else { completion(); return }
       _ = DSMManager.logout()


### PR DESCRIPTION
Takes the main-thread fix from #2 so it can ship in 2.0.0 without waiting on the modal-dismissal work in that PR, which is a separate design question. First commit is @virajpsimformsolutions' original, cherry-picked unchanged. The two after it are the review follow-up.

**Merge with rebase, not squash.** Squashing collapses the contributor's commit into mine and drops the attribution.

## The bug

Expo dispatches a synchronous `AsyncFunction` body on a serial background queue, so JS-originated calls arrive off-main. `DSMManager` and `WKWebsiteDataStore` are main-thread only. `endSigningSession` reached `clearAllWebCookies()` and `logout()` directly from that background queue on every call, including the one `useDocuSignSigning`'s `reset()` makes between signing flows.

`performLogin` already hopped to main, which is why this only bit the teardown paths.

## The follow-up

The hop landed inside `endSigningSession`, below the `stateQueue.sync` that cancels an in-flight signing promise. Re-entering the function from main therefore ran that cancellation block a second time. Empty slot makes it harmless, but a `presentCaptiveSigning` arriving between the two passes gets cancelled by the redundant one.

Moved the guard into `clearWebCookiesAsync`. It is the only method reaching `DSMManager.clearAllWebCookies()` and `WKWebsiteDataStore` directly, so one guard covers `performLogin`, `endSigningSession` and `reset`, and no caller has to know the threading contract. Its completion is already wrapped in `DispatchQueue.main.async`, so the `DSMManager.logout()` each caller runs from it stays on main.

`reset()` loses its own hop for the same reason. It sat below the same cancellation block and had the same re-entrant double-execution, so this closes that race as well.

Also drops a `pendingResolved` var in `endSigningSession` that was assigned, never read, and carried a line existing only to silence the resulting warning.

## Verification

`swiftc -parse` clean, `npm run build`, `npm run lint`, 18/18 Jest.

A threading review traced every `stateQueue` call site for a cycle with main and found none, confirmed `logout()` and `removeObserver` still land on main through the completion dispatch, and confirmed `completion()` is invoked exactly once on every path including `reset()`'s `needsTeardown` early return.

Stating the limit plainly, same as #7: CI compiles no Swift and runs no iOS tests, so nothing here catches a type error in this file. Verified by parsing and by reading. A device run before tagging 2.0.0 is the honest bar.

## Not included from #2

The force-dismiss commit stays there. It dismisses from the key window's root view controller while both present paths use `topmostViewController()`, so it tears down the host app's own modal whenever signing was started from a sheet. Fixing that needs a reference to the controller actually presented, which touches the present path too. Tracked on #2.
